### PR TITLE
SHALLOT-15 Throw clearer errors from mixin getter functions

### DIFF
--- a/packages/core/src/utils/mixins/index.ts
+++ b/packages/core/src/utils/mixins/index.ts
@@ -27,33 +27,62 @@ export const getColorShade = (address: string | undefined) => {
 
 export const getRadius =
   (value: keyof DefaultTheme['radii']) =>
-  ({ theme }: { theme: DefaultTheme }) =>
-    theme.radii[value]
+  ({ theme }: { theme: DefaultTheme }) => {
+    if (!theme?.radii?.[value])
+      console.warn(
+        `Radius not found for value "${value}". Are you sure it's defined in your theme and you're using a ThemeProvider?`,
+      )
+    return theme.radii[value]
+  }
 
 export const getLetterSpacing =
   (value: keyof DefaultTheme['letterSpacings']) =>
-  ({ theme }: { theme: DefaultTheme }) =>
-    theme.letterSpacings[value]
-
+  ({ theme }: { theme: DefaultTheme }) => {
+    if (!theme?.letterSpacings?.[value])
+      console.warn(
+        `Letter spacing not found for value "${value}". Are you sure it's defined in your theme and you're using a ThemeProvider?`,
+      )
+    return theme.letterSpacings[value]
+  }
 export const getLineHeight =
   (value: keyof DefaultTheme['lineHeights']) =>
-  ({ theme }: { theme: DefaultTheme }) =>
-    theme.lineHeights[value]
+  ({ theme }: { theme: DefaultTheme }) => {
+    if (!theme?.lineHeights?.[value])
+      console.warn(
+        `Line height not found for value "${value}". Are you sure it's defined in your theme and you're using a ThemeProvider?`,
+      )
+    return theme.lineHeights[value]
+  }
 
 export const getFontSize =
   (value: keyof DefaultTheme['fontSizes']) =>
-  ({ theme }: { theme: DefaultTheme }) =>
-    theme.fontSizes[value]
+  ({ theme }: { theme: DefaultTheme }) => {
+    if (!theme?.fontSizes?.[value])
+      console.warn(
+        `Font size not found for value "${value}". Are you sure it's defined in your theme and you're using a ThemeProvider?`,
+      )
+    return theme.fontSizes[value]
+  }
 
 export const getUnits =
   (value: number) =>
-  ({ theme }: { theme: DefaultTheme }) =>
-    theme.gridUnits[0] * value
+  ({ theme }: { theme: DefaultTheme }) => {
+    if (!theme?.gridUnits?.[value])
+      console.warn(
+        `gridUnit not found for value "${value}". Are you sure it's defined in your theme and you're using a ThemeProvider?`,
+      )
+    return theme.gridUnits[value]
+  }
 
 export const getElevation =
   (value: keyof DefaultTheme['elevations']) =>
-  ({ theme }: { theme: DefaultTheme }) =>
-    theme.elevations[value]
+  ({ theme }: { theme: DefaultTheme }) => {
+    if (!theme?.elevations?.[value])
+      console.warn(
+        `Elevation not found for value "${value}". Are you sure it's defined in your theme and you're using a ThemeProvider?`,
+      )
+    return theme.elevations[value]
+  }
 
 export const getNumericValue = (value: boolean | number) => {
   if (typeof value === 'boolean') return value ? 1 : 0

--- a/packages/core/src/utils/mixins/index.ts
+++ b/packages/core/src/utils/mixins/index.ts
@@ -5,7 +5,7 @@ export const getColor =
   (value: keyof DefaultTheme['colors'], shade: ColorShadingValue) =>
   ({ theme }: { theme: DefaultTheme }) => {
     const color =
-      theme.colors[value][shade as keyof typeof theme.colors.Shading]
+      theme.colors?.[value]?.[shade as keyof typeof theme.colors.Shading]
     if (!color)
       console.warn(
         `Color not found for value "${value}" and shade "${shade}". Are you sure it's defined in your theme and you're using a ThemeProvider?`,

--- a/packages/core/src/utils/mixins/index.ts
+++ b/packages/core/src/utils/mixins/index.ts
@@ -7,7 +7,9 @@ export const getColor =
     const color =
       theme.colors[value][shade as keyof typeof theme.colors.Shading]
     if (!color)
-      console.warn(`color not found for value "${value}" and shade "${shade}"`)
+      console.warn(
+        `Color not found for value "${value}" and shade "${shade}". Are you sure it's defined in your theme and you're using a ThemeProvider?`,
+      )
     return color
   }
 
@@ -22,6 +24,11 @@ export const getColorShade = (address: string | undefined) => {
     keyof DefaultTheme['colors'],
     ColorShadingValue,
   ]
+  if (!shade) {
+    console.warn(
+      `Color shade not found for value "${address}". Are you sure it's defined in your theme and you're using a ThemeProvider?`,
+    )
+  }
   return getColor(color, shade)
 }
 

--- a/platforms/web/styles/index.ts
+++ b/platforms/web/styles/index.ts
@@ -56,7 +56,7 @@ export const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
 
   body {
     color: ${({ theme, textColor }) =>
-      getColorShade(textColor ?? 'Shading.950', theme)};
+      getColorShade(textColor ?? 'Shading.900', theme)};
     background-color: ${({ theme, backgroundColor }) =>
       getColorShade(backgroundColor ?? 'Shading.50', theme)};
   }

--- a/platforms/web/styles/index.ts
+++ b/platforms/web/styles/index.ts
@@ -56,7 +56,7 @@ export const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
 
   body {
     color: ${({ theme, textColor }) =>
-      getColorShade(textColor ?? 'Shading.900', theme)};
+      getColorShade(textColor ?? 'Shading.950', theme)};
     background-color: ${({ theme, backgroundColor }) =>
       getColorShade(backgroundColor ?? 'Shading.50', theme)};
   }


### PR DESCRIPTION
Adds clearer console warnings to getRadius, getLetterSpacing, getLineHeight, getFontSize, getUnits, getElevation

For example:
`Radius not found for value "${value}". Are you sure it's defined in your theme and you're using a ThemeProvider?`