### PR TITLE
Add-variant-prop-to-Column

### DIFF
--- a/apps/storybook/stories/containers/Column.stories.tsx
+++ b/apps/storybook/stories/containers/Column.stories.tsx
@@ -41,7 +41,17 @@ export default {
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template: StoryFn<typeof Column> = (args) => (
-  <ThemeProvider theme={makeTheme({})}>
+  <ThemeProvider
+    theme={makeTheme({
+      variants: {
+        c1: {
+          backgroundColor: {
+            default: 'red',
+          },
+        },
+      },
+    })}
+  >
     <Column
       shallot={{
         backgroundColor: getColor('Shading', 150),
@@ -80,6 +90,7 @@ const Template: StoryFn<typeof Column> = (args) => (
           }}
         />
         <Column
+          variant="c1"
           shallot={{
             backgroundColor: getColor('Shading', 100),
             borderRadius: getRadius(args.radius),

--- a/apps/storybook/stories/containers/Column.stories.tsx
+++ b/apps/storybook/stories/containers/Column.stories.tsx
@@ -45,9 +45,7 @@ const Template: StoryFn<typeof Column> = (...args) => (
     theme={makeTheme({
       variants: {
         Box: {
-          columnVariant: {
-            width: '500px',
-          },
+          columnVariant: {},
         },
       },
     })}
@@ -90,7 +88,7 @@ const Template: StoryFn<typeof Column> = (...args) => (
           }}
         />
         <Column
-          variant="c1"
+          variant="columnVariant"
           shallot={{
             backgroundColor: getColor('Shading', 100),
             borderRadius: getRadius(args.radius),

--- a/apps/storybook/stories/containers/Column.stories.tsx
+++ b/apps/storybook/stories/containers/Column.stories.tsx
@@ -40,13 +40,13 @@ export default {
 } as Meta<typeof Column>
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: StoryFn<typeof Column> = (args) => (
+const Template: StoryFn<typeof Column> = (...args) => (
   <ThemeProvider
     theme={makeTheme({
       variants: {
-        c1: {
-          backgroundColor: {
-            default: 'red',
+        Box: {
+          columnVariant: {
+            backgroundColor: 'red',
           },
         },
       },
@@ -108,6 +108,12 @@ const Template: StoryFn<typeof Column> = (args) => (
 export const Default = Template.bind({})
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Default.args = {
+  backgroundColor: 'Shading.100',
+  radius: 'xl',
+}
+export const Variant = Template.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+Variant.args = {
   backgroundColor: 'Shading.100',
   radius: 'xl',
 }

--- a/apps/storybook/stories/containers/Column.stories.tsx
+++ b/apps/storybook/stories/containers/Column.stories.tsx
@@ -46,7 +46,7 @@ const Template: StoryFn<typeof Column> = (...args) => (
       variants: {
         Box: {
           columnVariant: {
-            backgroundColor: 'red',
+            width: '500px',
           },
         },
       },

--- a/components/Box/types.ts
+++ b/components/Box/types.ts
@@ -29,4 +29,8 @@ export type BoxStyleProps = AlignmentProps &
   SizingProps
 
 export type BoxProps<T = {}> = T &
-  BoxStyleProps & { shallot?: BoxShallot; children: ReactNode | ReactNode[] }
+  BoxStyleProps & {
+    shallot?: BoxShallot
+    // variant?: string
+    children: ReactNode | ReactNode[]
+  }

--- a/components/Box/utils/getShallotProp.ts
+++ b/components/Box/utils/getShallotProp.ts
@@ -12,6 +12,8 @@ import {
 } from '@shallot-ui/core'
 
 import { BoxProps, BoxShallot } from '../types'
+import { useTheme } from 'styled-components'
+import { ShallotProp } from '@shallot-ui/theme'
 
 const getShallotProp = <T>(props: BoxProps<T>): BoxShallot => {
   const baseShallot: BoxShallot = applyStyles({
@@ -20,7 +22,10 @@ const getShallotProp = <T>(props: BoxProps<T>): BoxShallot => {
     ...props.shallot,
   })
 
+  const theme = useTheme()
+
   return applyStyles(baseShallot, {
+    // ...theme?.variants?.Box?.[props.variant],
     ...getAlignmentShallot(baseShallot.flexDirection, props),
     ...getBorderShallot(props),
     ...getBackgroundColorShallot(props),

--- a/components/Column/types.ts
+++ b/components/Column/types.ts
@@ -32,6 +32,6 @@ export type ColumnShallot = ShallotProp & {
 export type ColumnProps<T = {}> = T &
   ColumnStyleProps & {
     shallot?: ColumnShallot
-    variant: string | 'default'
+    variant: string
     children?: ReactNode | ReactNode[]
   }

--- a/components/Column/types.ts
+++ b/components/Column/types.ts
@@ -32,5 +32,6 @@ export type ColumnShallot = ShallotProp & {
 export type ColumnProps<T = {}> = T &
   ColumnStyleProps & {
     shallot?: ColumnShallot
-    children: ReactNode | ReactNode[]
+    variant: string | 'default'
+    children?: ReactNode | ReactNode[]
   }

--- a/components/Column/utils/getShallotProp.ts
+++ b/components/Column/utils/getShallotProp.ts
@@ -23,7 +23,6 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
 
   const theme = useTheme()
   const { variant } = props
-  console.log('theme', theme?.variants?.Box?.[variant], 'variant', variant)
 
   return applyStyles(baseShallot, {
     ...getAlignmentShallot(baseShallot.flexDirection, props),
@@ -37,7 +36,7 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
     ...getSizingShallot(props),
 
     // Variants (overrides)
-    ...theme?.variants?.Box?.[props.variant],
+    ...theme?.variants?.Box?.[variant],
   })
 }
 

--- a/components/Column/utils/getShallotProp.ts
+++ b/components/Column/utils/getShallotProp.ts
@@ -23,6 +23,7 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
 
   const theme = useTheme()
   const { variant } = props
+  const themeVariant = theme?.variants?.Box?.[variant] as ColumnShallot
 
   return applyStyles(baseShallot, {
     ...getAlignmentShallot(baseShallot.flexDirection, props),
@@ -36,7 +37,7 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
     ...getSizingShallot(props),
 
     // Variants (overrides)
-    ...theme?.variants?.Box?.[variant],
+    ...themeVariant,
   })
 }
 

--- a/components/Column/utils/getShallotProp.ts
+++ b/components/Column/utils/getShallotProp.ts
@@ -22,6 +22,8 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
   })
 
   const theme = useTheme()
+  const { variant } = props
+  console.log('theme', theme?.variants?.Box?.[variant], 'variant', variant)
 
   return applyStyles(baseShallot, {
     ...getAlignmentShallot(baseShallot.flexDirection, props),

--- a/components/Column/utils/getShallotProp.ts
+++ b/components/Column/utils/getShallotProp.ts
@@ -22,7 +22,7 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
   })
 
   const theme = useTheme()
-  const { variant } = props
+  const { variant = 'default' } = props
   const themeVariant = theme?.variants?.Box?.[variant] as ColumnShallot
 
   return applyStyles(baseShallot, {

--- a/components/Column/utils/getShallotProp.ts
+++ b/components/Column/utils/getShallotProp.ts
@@ -24,7 +24,6 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
   const theme = useTheme()
 
   return applyStyles(baseShallot, {
-    ...theme?.variants?.Box?.[props.variant],
     ...getAlignmentShallot(baseShallot.flexDirection, props),
     ...getBorderShallot(props),
     ...getBackgroundColorShallot(props),
@@ -34,6 +33,9 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
     ...getMarginShallot(props),
     ...getRadiusShallot(props),
     ...getSizingShallot(props),
+
+    // Variants (overrides)
+    ...theme?.variants?.Box?.[props.variant],
   })
 }
 

--- a/components/Column/utils/getShallotProp.ts
+++ b/components/Column/utils/getShallotProp.ts
@@ -13,6 +13,7 @@ import {
 
 import { ColumnProps, ColumnShallot } from '../types'
 import { useTheme } from 'styled-components'
+import { Variant } from '@shallot-ui/theme'
 
 const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
   const baseShallot: ColumnShallot = applyStyles({
@@ -23,7 +24,9 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
 
   const theme = useTheme()
   const { variant = 'default' } = props
-  const themeVariant = theme?.variants?.Box?.[variant] as ColumnShallot
+  const themeVariant = theme?.variants?.Box?.[variant] as
+    | Variant<ColumnShallot>
+    | undefined
 
   return applyStyles(baseShallot, {
     ...getAlignmentShallot(baseShallot.flexDirection, props),

--- a/components/Column/utils/getShallotProp.ts
+++ b/components/Column/utils/getShallotProp.ts
@@ -12,6 +12,7 @@ import {
 } from '@shallot-ui/core'
 
 import { ColumnProps, ColumnShallot } from '../types'
+import { useTheme } from 'styled-components'
 
 const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
   const baseShallot: ColumnShallot = applyStyles({
@@ -20,7 +21,10 @@ const getShallotProp = <T>(props: ColumnProps<T>): ColumnShallot => {
     ...props.shallot,
   })
 
+  const theme = useTheme()
+
   return applyStyles(baseShallot, {
+    ...theme?.variants?.Box?.[props.variant],
     ...getAlignmentShallot(baseShallot.flexDirection, props),
     ...getBorderShallot(props),
     ...getBackgroundColorShallot(props),


### PR DESCRIPTION
- Storybook requires you to place a `variant` prop on the component itself. Does not work when used as an `arg` on a template