### PR TITLE
feat: explicitly export csstype

### DIFF
--- a/platforms/nextjs/src/index.ts
+++ b/platforms/nextjs/src/index.ts
@@ -2,3 +2,5 @@ import type {} from 'csstype'
 
 export * from './components'
 export * from './theme'
+
+export type { CSS } from '@shallot-ui/core-theme'

--- a/platforms/react/src/index.ts
+++ b/platforms/react/src/index.ts
@@ -6,3 +6,5 @@ export * from './context'
 export * from './styles'
 export * from './utils'
 export * from './theme'
+
+export type { CSS } from '@shallot-ui/core-theme'


### PR DESCRIPTION
This should fixe issues like:
```
 The inferred type of 'default' cannot be named without a reference to '.pnpm/csstype@3.1.3/node_modules/csstype'. This is likely not portable. A type annotation is necessary.
```